### PR TITLE
feat: added azure model name matching to find_model

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -10,7 +10,7 @@
 | Hugging Face Hub | `huggingface-hub`      | [Guide for Hugging Face Hub :octicons-link-16:](tutorial/providers/huggingface_hub.md) |
 | LiteLLM          | `litellm`              | [Guide for LiteLLM :octicons-link-16:](tutorial/providers/litellm.md)                  |
 | Mistral AI       | `mistralai`            | [Guide for Mistral AI :octicons-link-16:](tutorial/providers/mistralai.md)             |
-| OpenAI           | `openai`               | [Guide for OpenAI :octicons-link-16:](tutorial/providers/openai.md)                    |
+| OpenAI           | `openai`               | [Guide for OpenAI (including Azure) :octicons-link-16:](tutorial/providers/openai.md)                    |
 
 
 ## Chat Completions

--- a/docs/tutorial/providers/openai.md
+++ b/docs/tutorial/providers/openai.md
@@ -73,6 +73,34 @@ Integrating EcoLogits with your applications does not alter the standard outputs
     
     asyncio.run(main())
     ```
+### Azure OpenAI example
+
+Under the hood it is the same function that is called by the Azure OpenAI client. Hence the impacts attribute will automatically be added to the response object.
+
+=== "Azure"
+```python
+from ecologits import EcoLogits
+from openai import AzureOpenAI
+
+# Initialize EcoLogits
+EcoLogits.init()
+
+client = AzureOpenAI(
+        azure_endpoint= "http://myazureendpoint",
+        api_key=os.getenv("AZURE_OPENAI_API_KEY"),
+        api_version=os.getenv("OPENAI_API_VERSION"),
+    )
+
+response = client.chat.completions.create(
+    model="gpt-3.5-turbo",
+    messages=[
+        {"role": "user", "content": "Tell me a funny joke!"}
+    ]
+)
+
+# Get estimated environmental impacts of the inference
+print(response.impacts)
+```
 
 ### Streaming example
 

--- a/docs/tutorial/providers/openai.md
+++ b/docs/tutorial/providers/openai.md
@@ -108,25 +108,25 @@ print(response.impacts)
 
 === "Sync" 
 
-    ```python
-    from ecologits import EcoLogits
-    from openai import OpenAI
-    
-    # Initialize EcoLogits
-    EcoLogits.init()
-    
-    client = OpenAI(api_key="<OPENAI_API_KEY>")
-    
-    stream = client.chat.completions.create(
-        model="gpt-3.5-turbo",
-        messages=[{"role": "user", "content": "Hello World!"}],
-        stream=True
-    )
-    
-    for chunk in stream:
-        # Get cumulative estimated environmental impacts of the inference
-        print(chunk.impacts)
-    ```
+```python
+from ecologits import EcoLogits
+from openai import OpenAI
+
+# Initialize EcoLogits
+EcoLogits.init()
+
+client = OpenAI(api_key="<OPENAI_API_KEY>")
+
+stream = client.chat.completions.create(
+    model="gpt-3.5-turbo",
+    messages=[{"role": "user", "content": "Hello World!"}],
+    stream=True
+)
+
+for chunk in stream:
+    # Get cumulative estimated environmental impacts of the inference
+    print(chunk.impacts)
+```
 
 === "Async"
 

--- a/ecologits/__init__.py
+++ b/ecologits/__init__.py
@@ -1,6 +1,6 @@
 from .ecologits import EcoLogits
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 __all__ = [
     "__version__",
     "EcoLogits"

--- a/ecologits/model_repository.py
+++ b/ecologits/model_repository.py
@@ -31,14 +31,13 @@ class Model:
 
 
 class ModelRepository:
-
     def __init__(self, models: list[Model]) -> None:
         self.__models = models
 
     def find_model(self, provider: str, model_name: str) -> Optional[Model]:
         for model in self.__models:
             # To handle specific LiteLLM calling (e.g., mistral/mistral-small)
-            if model.provider == provider and model.name in model_name:
+            if model.provider == provider and (model.name in model_name or model.name.replace(".", "") == model_name):
                 return model
         return None
 
@@ -51,9 +50,7 @@ class ModelRepository:
     @classmethod
     def from_csv(cls, filepath: Optional[str] = None) -> "ModelRepository":
         if filepath is None:
-            filepath = os.path.join(
-                os.path.dirname(os.path.realpath(__file__)), "data", "models.csv"
-            )
+            filepath = os.path.join(os.path.dirname(os.path.realpath(__file__)), "data", "models.csv")
         models = []
         with open(filepath) as fd:
             csv = DictReader(fd)
@@ -61,18 +58,14 @@ class ModelRepository:
                 total_parameters = None
                 total_parameters_range = None
                 if ";" in row["total_parameters"]:
-                    total_parameters_range = [
-                        float(p) for p in row["total_parameters"].split(";")
-                    ]
+                    total_parameters_range = [float(p) for p in row["total_parameters"].split(";")]
                 elif row["total_parameters"] != "":
                     total_parameters = float(row["total_parameters"])
 
                 active_parameters = None
                 active_parameters_range = None
                 if ";" in row["active_parameters"]:
-                    active_parameters_range = [
-                        float(p) for p in row["active_parameters"].split(";")
-                    ]
+                    active_parameters_range = [float(p) for p in row["active_parameters"].split(";")]
                 elif row["active_parameters"] != "":
                     active_parameters = float(row["active_parameters"])
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1709,7 +1709,7 @@ Jinja2 = ">=2.11.1"
 Markdown = ">=3.3"
 MarkupSafe = ">=1.1"
 mkdocs = ">=1.4"
-mkdocs-autorefs = ">=0.3.1"
+mkdocs-autorefs = ">=0.3.2"
 mkdocstrings-python = {version = ">=0.5.2", optional = true, markers = "extra == \"python\""}
 platformdirs = ">=2.2.0"
 pymdown-extensions = ">=6.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "ecologits"
-version = "0.3.1"
+version = "0.3.2"
 description = "EcoLogits tracks and estimates the energy consumption and environmental impacts of using generative AI models through APIs."
 authors = [
     "GenAI Impact",

--- a/tests/test_model_repository.py
+++ b/tests/test_model_repository.py
@@ -13,6 +13,10 @@ def test_create_model_repository_from_scratch():
     ])
     assert models.find_model(provider="provider-test", model_name="model-test")
 
+def test_find_azure_openai_model():
+    models = ModelRepository.from_csv()
+    assert models.find_model(provider="openai", model_name="gpt-35-turbo").name =="gpt-3.5-turbo"
+
 
 def test_find_unknown_provider():
     models = ModelRepository.from_csv()


### PR DESCRIPTION
_Adressing: https://github.com/genai-impact/ecologits/issues/60_

**Context:**
Though the wrapped class is the same for Azure OpenAI, there is a difference in the model names: azure does not use dots in the name (chatgpt-3.5 in openai API becomes chatgpt-35 in azure).

**Impacts:**
The matching in find_models methods now checks if the name with deleted dots matches a name in the provider's models' names.
The choice was made not to add azure as a provider and to consider a model running on either azure or openai infrastructure has the same impacts, this could be discussed.

**Side effects:**
As of right now, there is no side effects (no false positive matching) but further down the line too many provider specific matching rules could become a hassle to maintain.

- [x] added docs: example using AzureOpenAI client
- [x] added unit test checking that the names used in azure now match model name in the csv file